### PR TITLE
fix: harden proxy error responses, meta endpoint auth, and regex validation

### DIFF
--- a/src/guardette/default_actions/filter_regex.py
+++ b/src/guardette/default_actions/filter_regex.py
@@ -2,18 +2,29 @@ import typing
 import re
 
 from guardette.actions import action_registry, Action, ActionContext
-from pydantic import Field
+from pydantic import Field, model_validator
 
 
 @action_registry.register("filter_regex")
 class FilterRegex(Action):
+    model_config = {"arbitrary_types_allowed": True}
+
     json_paths: typing.List[str]
     regex_pattern: str
     delimiter: str = Field(default="")
+    compiled_pattern: typing.Optional[re.Pattern] = None
+
+    @model_validator(mode="after")
+    def compile_regex(self):
+        try:
+            self.compiled_pattern = re.compile(self.regex_pattern, re.I)
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern '{self.regex_pattern}'") from e
+        return self
 
     async def response(self, ctx: ActionContext):
         def updater(text, data, k):
-            matches = re.findall(self.regex_pattern, text, re.I)
+            matches = self.compiled_pattern.findall(text)
             return self.delimiter.join(matches)
 
         for path in self.json_paths:

--- a/src/guardette/default_actions/redact_regex.py
+++ b/src/guardette/default_actions/redact_regex.py
@@ -1,19 +1,32 @@
 import typing
 import re
 
+from pydantic import model_validator
+
 from guardette.actions import action_registry, Action, ActionContext
 
 
 @action_registry.register("redact_regex")
 class RedactRegex(Action):
+    model_config = {"arbitrary_types_allowed": True}
+
     json_paths: typing.List[str]
     regex_pattern: str
+    compiled_pattern: typing.Optional[re.Pattern] = None
+
+    @model_validator(mode="after")
+    def compile_regex(self):
+        try:
+            self.compiled_pattern = re.compile(self.regex_pattern, re.I)
+        except re.error as e:
+            raise ValueError(f"Invalid regex pattern '{self.regex_pattern}'") from e
+        return self
 
     async def response(self, ctx: ActionContext):
         def updater(text, data, k):
             if not isinstance(text, str):
                 return text
-            return re.sub(self.regex_pattern, ctx.config.REDACT_TOKEN, text, flags=re.I)
+            return self.compiled_pattern.sub(ctx.config.REDACT_TOKEN, text)
 
         for path in self.json_paths:
             ctx.update_json_path(ctx.response.json_data, path, updater)

--- a/src/guardette/proxy.py
+++ b/src/guardette/proxy.py
@@ -110,7 +110,6 @@ def guardette_route():
                         "error": {
                             "message": "Internal Server Error",
                             "source": "proxy",
-                            "details": str(ge),
                             "correlation_id": correlation_id,
                         },
                     },
@@ -174,8 +173,20 @@ class Guardette:
     def matcher(self):
         return self._matcher
 
+    async def _validate_client_secret(self, request: Request):
+        req_client_secret = request.headers.get("authorization")
+        if not req_client_secret:
+            raise AuthException("Missing authorization header.")
+
+        client_secret = await self.secrets.get('CLIENT_SECRET', correlation_id=request.state.correlation_id)
+
+        if not compare_digest(req_client_secret, client_secret):
+            raise AuthException("Invalid authorization header.")
+
     @guardette_route()
     async def _meta_route(self, request: Request):
+        await self._validate_client_secret(request)
+
         return JSONResponse(
             content={
                 "version": VERSION,
@@ -186,14 +197,7 @@ class Guardette:
 
     @guardette_route()
     async def _proxy_route(self, request: Request):
-        req_client_secret = request.headers.get("authorization")
-        if not req_client_secret:
-            raise AuthException("Missing authorization header.")
-
-        client_secret = await self.secrets.get('CLIENT_SECRET', correlation_id=request.state.correlation_id)
-
-        if not compare_digest(req_client_secret, client_secret):
-            raise AuthException("Invalid authorization header.")
+        await self._validate_client_secret(request)
 
         target_host = request.headers.get(PROXY_HOST_HEADER)
         if not target_host:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -95,15 +95,23 @@ def test_proxy_timeout(mock_get, mock_match, mock_transform_request, mock_secret
     )
     assert response.status_code == 500, response.text
     assert response.json()["error"]["source"] == "proxy"
-    assert "Request timed out" in response.json()["error"]["details"]
+    assert "details" not in response.json()["error"]
     assert response.headers.get(PROXY_ERROR_HEADER) == "proxy"
 
 @patch("guardette.secrets.ConfigSecretsManager.get", side_effect=get_secret)
 def test_meta_route(mock_get):
-    response = client.get("/_guardette/meta")
+    response = client.get("/_guardette/meta",
+                          headers={"Authorization": test_client_secret})
     assert response.status_code == 200, response.text
     data = response.json()
 
     # Verify that the response contains the expected keys
     assert "version" in data, "Response should contain 'version'"
     assert "policy" in data, "Response should contain 'policy'"
+
+
+@patch("guardette.secrets.ConfigSecretsManager.get", side_effect=get_secret)
+def test_meta_route_requires_auth(mock_get):
+    response = client.get("/_guardette/meta")
+    assert response.status_code == 500
+    assert response.headers.get(PROXY_ERROR_HEADER) == "proxy"


### PR DESCRIPTION

- Remove internal error details from client-facing responses
- Require authentication on /_guardette/meta endpoint
- Validate and pre-compile regex patterns at policy load time