### PR TITLE
fix: redact full GitLab/GitHub tokens, not just the prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Guardette Documentation
+# Guardette
 
 Guardette is a **redacting proxy layer** that sits between the REST APIs of your data sources and vendors who require access to a subset of that data. By leveraging Guardette, you can achieve **more secure and granular access control** through customizable redaction and allow-listing rules defined in a YAML file.
 

--- a/src/guardette/default_actions/redact_secrets.py
+++ b/src/guardette/default_actions/redact_secrets.py
@@ -1,7 +1,31 @@
+from contextlib import contextmanager
+
 from detect_secrets.core.scan import _process_line_based_plugins
+from detect_secrets.plugins.base import RegexBasedDetector
 from detect_secrets.settings import default_settings
 
 from guardette.actions import Action, ActionContext, action_registry
+
+
+@contextmanager
+def _full_match_regex_detectors():
+    # Upstream RegexBasedDetector.analyze_string uses re.findall, which returns
+    # only captured groups when present. Several built-in plugins (GitLab,
+    # GitHub, ...) use capturing groups for alternation rather than secret
+    # extraction, so the yielded secret_value is the prefix only. Swap in
+    # finditer + group(0) so the whole token is what gets redacted.
+    original = RegexBasedDetector.analyze_string
+
+    def patched(self, string):
+        for regex in self.denylist:
+            for match in regex.finditer(string):
+                yield match.group(0)
+
+    RegexBasedDetector.analyze_string = patched
+    try:
+        yield
+    finally:
+        RegexBasedDetector.analyze_string = original
 
 
 @action_registry.register("redact_secrets")
@@ -28,7 +52,7 @@ class RedactSecrets(Action):
                     redacted = redacted.replace(sv, token)
             return redacted
 
-        with default_settings() as settings:
+        with default_settings() as settings, _full_match_regex_detectors():
             # Always redact, even if upstream content contains an
             # `# pragma: allowlist secret` directive.
             settings.disable_filters("detect_secrets.filters.allowlist.is_line_allowlisted")

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -131,3 +131,51 @@ async def test_redact_secrets_ignores_allowlist(action_context):
     assert action_context.response.json_data == {
         "body": f'AWS_KEY = "{redact_token}"  # pragma: allowlist secret',
     }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "token",
+    [
+        "glpat-abcdefghijklmnopqrst",
+        "gldt-abcdefghijklmnopqrst",
+        "glft-abcdefghijklmnopqrst",
+        "glsoat-abcdefghijklmnopqrst",
+        "glrt-abcdefghijklmnopqrst",
+        "glcbt-abcdefghijklmnopqrst",
+        "glcbt-ab_cdefghijklmnopqrstuv",
+        "glagent-" + "a" * 50,
+        "gloas-" + "a" * 64,
+        "ghp_" + "a" * 36,
+        "gho_" + "a" * 36,
+        "ghu_" + "a" * 36,
+        "ghs_" + "a" * 36,
+        "ghr_" + "a" * 36,
+    ],
+)
+async def test_redact_secrets_token_variants(action_context, token):
+    redact_token = action_context.config.REDACT_TOKEN
+    action = action_registry.get_action_cls("redact_secrets").model_validate(dict(json_paths=["$.body"]))
+    action_context.response.json_data = {"body": f'TOKEN = "{token}"'}
+
+    await action.response(action_context)
+
+    assert token not in action_context.response.json_data["body"]
+    assert action_context.response.json_data == {"body": f'TOKEN = "{redact_token}"'}
+
+
+@pytest.mark.anyio
+async def test_redact_secrets_multiple_tokens(action_context):
+    redact_token = action_context.config.REDACT_TOKEN
+    pat1 = "glpat-abcdefghijklmnopqrst"
+    pat2 = "glpat-zyxwvutsrqponmlkjihg"
+
+    action = action_registry.get_action_cls("redact_secrets").model_validate(dict(json_paths=["$.body"]))
+    action_context.response.json_data = {"body": f'A = "{pat1}"\nB = "{pat2}"'}
+
+    await action.response(action_context)
+
+    body = action_context.response.json_data["body"]
+    assert "abcdefghijklmnopqrst" not in body
+    assert "zyxwvutsrqponmlkjihg" not in body
+    assert body == f'A = "{redact_token}"\nB = "{redact_token}"'


### PR DESCRIPTION
detect_secrets' RegexBasedDetector.analyze_string uses re.findall, which returns only captured groups when a regex has any. Several plugins use capturing groups for alternation — e.g. (glpat|gldt|...)-... — so the yielded secret_value is the prefix only, and our str.replace leaves the random suffix untouched. A `glpat-...` PAT was being redacted to `[REDACTED]-abcdefghijklmnopqrst`.

Patch RegexBasedDetector.analyze_string in a scoped context manager to use finditer + group(0), so the whole token is what gets redacted. Universal — covers GitLab, GitHub, and any other RegexBasedDetector with the same bug shape. Added parametrized tests covering 9 GitLab token types and 5 GitHub token types.