### PR TITLE
fix: update gitlab template to include current user endpoint

### DIFF
--- a/scripts/policygen/sources/gitlab/template.yml
+++ b/scripts/policygen/sources/gitlab/template.yml
@@ -2,6 +2,7 @@ source:
   host: {{ config.gitlab_domain | default("gitlab.com") }}
   auth: bearer_token:gitlab
   rules:
+    - route: "GET /api/v4/user"
     - route: "GET /api/v4/groups"
     - route: "GET /api/v4/groups/{groupId}"
     - route: "GET /api/v4/groups/{groupId}/descendant_groups"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single allowlist entry in a policy template; expands permitted read access to the authenticated user endpoint only, with no auth or core runtime changes.
> 
> **Overview**
> **GitLab policygen template** now includes **`GET /api/v4/user`** in the source `rules` list (placed before the existing group routes).
> 
> Generated GitLab proxy policies will **permit** requests to the current-user API endpoint, which was missing from the template before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a23b1e2a2cb1c5edd7a212450e38a36a05440c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->